### PR TITLE
Patch issue on ios 17.2

### DIFF
--- a/cordova-js-src/exec.js
+++ b/cordova-js-src/exec.js
@@ -112,7 +112,9 @@ var iOSExec = function () {
 
     // CB-10133 DataClone DOM Exception 25 guard (fast function remover)
     var command = [callbackId, service, action, JSON.parse(JSON.stringify(actionArgs))];
-    window.webkit.messageHandlers.cordova.postMessage(command);
+    if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.cordova) {
+        window.webkit.messageHandlers.cordova.postMessage(command);
+    }
 };
 
 iOSExec.nativeCallback = function (callbackId, status, message, keepCallback, debug) {


### PR DESCRIPTION
* when navigating away from a page with an iframe, this becomes null for some reason
* it fixes if you use an app bound domain, but that's not sustainable since you can only have 10
* so this works around the issue by not triggering a billion errors
